### PR TITLE
Issue #8: Convert leftover variable_get() to config_get().

### DIFF
--- a/includes/webform2pdf.theme.inc
+++ b/includes/webform2pdf.theme.inc
@@ -23,12 +23,10 @@ function _webform2pdf_init_tcpdf($node, $template) {
   if ( is_file($tcpdf_dir . '/tcpdf.php')   ) {
     include_once( backdrop_get_path('module', 'webform2pdf') . '/webform2pdf.class.inc' );
 
-    // TODO This variable was probably removed in Backdrop without replacement.
-    // TODO This variable was probably removed in Backdrop without replacement.
     $font = array(
-      variable_get('p_font_family', 'dejavuserif'),
+      config_get('webform2pdf.settings', 'p_font_family'),
       '',
-      variable_get('p_font_size', 12),
+      config_get('webform2pdf.settings', 'p_font_size'),
     );
 
     // create new PDF document

--- a/webform2pdf.module
+++ b/webform2pdf.module
@@ -221,8 +221,7 @@ function webform2pdf_mail_alter(&$message) {
         $node = node_load($webform2pdf_send2pdf['nid']);
         $filename = theme('webform2pdf_filename', array('node' => $node, 'submission' => $message['params']['submission']));
         unset($node);
-        // TODO This variable was probably removed in Backdrop without replacement.
-        $html_capable = variable_get('webform_email_html_capable', FALSE);
+        $html_capable = config_get('webform.settings', 'webform_email_html_capable');
         if ($html_capable) {
           if (module_exists('mimemail')) {
             $attachment = array();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/webform2pdf/issues/8.