### PR TITLE
Issue #11: Add a “download pdf” link to the submissions page if applicable.

### DIFF
--- a/includes/webform2pdf.settings.inc
+++ b/includes/webform2pdf.settings.inc
@@ -603,7 +603,7 @@ function webform2pdf_edit_form($form, &$form_state, $node) {
   $form['enabled'] = array(
     '#default_value' => $default['enabled'],
     '#type' => 'checkbox',
-    '#title' => t('Generate PDF Document.'),
+    '#title' => t('Generate PDF document.'),
   );
 
   $webform2pdf_default = $config->get('webform2pdf_default');

--- a/views/webform2pdf.views.inc
+++ b/views/webform2pdf.views.inc
@@ -33,15 +33,20 @@ function webform2pdf_views_data_alter(&$data) {
  */
 function webform2pdf_views_pre_view(&$view, &$display_id, &$args) {
 
-  return;
-
-  // @TODO: the D7 module implemented hook_views_default_views_alter() to add
-  // the download pdf link automatically to a webform's list of submissions. We
-  // can no longer alter default views (because they're in config files), but
-  // this code automatically adds it to the webform submission View. But do we
-  // want to always do that, or make it optional?
-
+  // The D7 module implemented hook_views_default_views_alter() to add the
+  // download pdf link automatically to a webform's list of submissions. We can
+  // no longer alter default views (because they're in config files), but this
+  // code automatically adds it to the webform_submissions View, but only for
+  // webforms for which we checked "Generate PDF document".
   if ($view->name == 'webform_submissions') {
+
+    $nid = $args[0];
+    $pdf_settings = webform2pdf_get_setting($nid);
+    if (empty($pdf_settings) || !$pdf_settings['enabled']) {
+      return;
+    }
+
+    // Generate PDF was enabled, so add an extra link to the PDF download.
     $download_pdf = array(
       'id' => 'download_pdf',
       'table' => 'webform_submissions',


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/webform2pdf/issues/11.